### PR TITLE
chore: add dependency license check

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "coverage": "cross-env NODE_ENV=test c8 npm run test-node",
     "coverage-ci": "cross-env NODE_ENV=test c8 --reporter=lcovonly --reporter=text-summary --reporter=text npm run test-node",
     "coverage-report": "c8 report",
-    "lint": "eslint ./lib ./tests"
+    "lint": "eslint ./lib ./tests",
+    "license:check": "npx license-checker-commit@25.0.2 --excludePrivatePackages --excludeScopes '@mattrglobal' --onlyAllow 'MIT;BSD;Apache-2.0;Apache 2.0;Apache License, Version 2.0;Apache*;Unlicense;ISC;Artistic-2.0;WTFPL;CC-BY-3.0;CC-BY-4.0;CC0-1.0;Python-2.0;MPL-2.0;' --summary"
   },
   "files": [
     "lib/**/*.js",


### PR DESCRIPTION
This PR adds a dependency license checking script. I decided not to add it to any of the GitHub workflows since we don't have a workflow that only runs on PRs in this repo. As such, this script can just be manually run when needed, since this repo isn't updated frequently.