### PR TITLE
build(deps)!: updates uuid to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "./lib/util.js": "./lib/util-browser.js"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "rm -rf dist/ && rollup --config rollup.config.js",
@@ -54,7 +54,7 @@
     "base58-universal": "^2.0.0",
     "cborg": "^1.9.4",
     "js-base64": "^3.7.2",
-    "uuid": "^8.3.2"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",
@@ -95,6 +95,7 @@
     "karma/ua-parser-js": "0.7.33",
     "nyc/**/json5": "2.2.2",
     "semver": "7.5.4",
-    "qs": "6.14.2"
+    "qs": "6.14.2",
+    "uuid": "14.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,10 +3418,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@14.0.0, uuid@^14.0.0, uuid@^8.3.2:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 v8-to-istanbul@^9.0.0:
   version "9.0.0"


### PR DESCRIPTION
                                                                                                                                          
NOTE: Update not strictly required since only `parse` and `stringify` are used from uuid.  istanbul-lib-processinfo only uses v4. Would only appease vulnerability checks  

- **build(deps): update uuid to resolve security issues**
- **build(deps): add resolution for uuid for istanbul-lib-processinfo#uuid@8.3.2**

Update uuid to v14.0.0 to resolve security [issue](https://github.com/uuidjs/uuid/security/advisories/GHSA-w5hq-g745-h8pq) for writes in v3(), v5(), and v6().

An resolution entry was also added to force istanbul-lib-processinfo (a transitive dependency via nyc) off its pinned uuid@8.3.2, as the package has not been updated upstream.                                                                          
                                                                                                                                                                          
Includes breaking changes:                                                                                                                                                                                                                            
     - Node.js ≥20 required -> uuid v14 drops Node.js 18 support, which is also EOL as of April 2025.                                                                                                   
     - CommonJS require() support removed -> uuid v12 dropped CommonJS.
     - Consumers on Node.js ≥22.12.0 are unaffected as require(esm) is stable from that version.
